### PR TITLE
feat: Add MacOS and Windows builds to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+    - name: Install Dependencies
+      run: sudo apt update && sudo apt install -y cmake
     - uses: actions/checkout@v3
-
     - name: Build
-      # TODO: Split these into separate lines.
-      run: sudo apt update && sudo apt install -y cmake && cmake -S . -B build && cmake --build build
+      run: cmake -S . -B build && cmake --build build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,21 @@
+name: MacOS CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: MacOS Build
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Dependencies
+        run: brew update && brew install cmake openssl@1.1
+
+      - name: Build Library
+        run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)" cmake -S . -B build  && cmake --build build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,21 @@
+name: Windows CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Choco install dependencies
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: install openssl cmake
+      - name: Build Library
+        run: cmake -S . -B build && cmake --build build


### PR DESCRIPTION
* Split dependency install to a separate step in linux build.
* Rename Linux file.

Resolves https://github.com/googleapis/enterprise-certificate-offload/issues/10.