### PR TITLE
fix: Go integration server uses a minimum TLS version of 1.3.

### DIFF
--- a/tests/testing_utils/server/server.go
+++ b/tests/testing_utils/server/server.go
@@ -35,6 +35,7 @@ func main() {
 	config := &tls.Config{
 		ClientAuth: tls.RequireAndVerifyClientCert,
 		ClientCAs:  caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}
 	config.BuildNameToCertificate()
 


### PR DESCRIPTION
This aligns the integration tests with the min TLS version requirements of the library.