### PR TITLE
refactor: ECP offload schema update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Unit Test
         run: ./build/offload_unit_test
       - name: Set up Signer Proxy Binaries
-        run: echo "Using go version: $(go version)" ./scripts/setup_signer_proxy.sh
+        run: echo "Using go version: $(go version)" && ./scripts/setup_signer_proxy.sh
       - name: Integration Test
         run: ./scripts/integration_test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Dependencies
-        run: brew update && brew install cmake openssl@1.1 go
+        run: brew update && brew install cmake openssl@1.1 go && go version
       - name: Build Library
         run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)" cmake -S . -B build -DENABLE_UNIT_TESTS=TRUE && cmake --build build
       - name: Unit Test
         run: ./build/offload_unit_test
       - name: Set up Signer Proxy Binaries
-        run: echo "Using go version: $(go version)" && ./scripts/setup_signer_proxy.sh
+        run: ./scripts/setup_signer_proxy.sh
       - name: Integration Test
         run: ./scripts/integration_test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Dependencies
-        run: brew update && brew install cmake openssl@1.1
+        run: brew update && brew install cmake openssl@1.1 go
       - name: Build Library
         run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)" cmake -S . -B build -DENABLE_UNIT_TESTS=TRUE && cmake --build build
       - name: Unit Test
         run: ./build/offload_unit_test
       - name: Set up Signer Proxy Binaries
-        run: ./scripts/setup_signer_proxy.sh
+        run: echo "Using go version: $(go version)"./scripts/setup_signer_proxy.sh
       - name: Integration Test
         run: ./scripts/integration_test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,10 +12,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Dependencies
-        run: brew update && brew install cmake openssl@1.1 go && go version
+        run: brew update && brew install cmake openssl@1.1
       - name: Build Library
         run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)" cmake -S . -B build -DENABLE_UNIT_TESTS=TRUE && cmake --build build
       - name: Unit Test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Unit Test
         run: ./build/offload_unit_test
       - name: Set up Signer Proxy Binaries
-        run: echo "Using go version: $(go version)"./scripts/setup_signer_proxy.sh
+        run: echo "Using go version: $(go version)" ./scripts/setup_signer_proxy.sh
       - name: Integration Test
         run: ./scripts/integration_test.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 find_package(OpenSSL 1.1.1 EXACT REQUIRED)
 
-add_library(certificate_offload SHARED
+add_library(tls_offload SHARED
   src/offload.cpp
 )
 
-target_link_libraries(certificate_offload OpenSSL::Crypto OpenSSL::SSL)
+target_link_libraries(tls_offload OpenSSL::Crypto OpenSSL::SSL)
 
 if (ENABLE_UNIT_TESTS)
   include(FetchContent)
@@ -48,7 +48,7 @@ if (ENABLE_UNIT_TESTS)
   target_link_libraries(
     offload_unit_test
     GTest::gtest_main
-    certificate_offload
+    tls_offload
   )
 
   include(GoogleTest)

--- a/scripts/setup_signer_proxy.sh
+++ b/scripts/setup_signer_proxy.sh
@@ -24,16 +24,16 @@ function set_up_env() {
   if [[ "$(uname)" == 'Linux' ]]; then
      BUILD_SCRIPT="build/scripts/linux_amd64.sh"
      SIGNER_BINARY="build/bin/linux_amd64/signer"
-     SIGNER_SHARED_LIB="build/bin/linux_amd64/signer.so"
+     SIGNER_SHARED_LIB="build/bin/linux_amd64/libsigner.so"
      TEST_BINARY_FOLDER="$PWD/tests/testing_utils/signer_binaries/linux64"
   elif [[ "$(uname)" == 'Darwin' ]]; then
      BUILD_SCRIPT="build/scripts/darwin_amd64.sh"
      SIGNER_BINARY="build/bin/darwin_amd64/signer"
-     SIGNER_SHARED_LIB="build/bin/darwin_amd64/signer.dylib"
+     SIGNER_SHARED_LIB="build/bin/darwin_amd64/libsigner.dylib"
      TEST_BINARY_FOLDER="$PWD/tests/testing_utils/signer_binaries/mac64"
   else
     echo "This script only supports Linux and MacOS."
-    exit 1 
+    exit 1
   fi
 }
 

--- a/scripts/setup_signer_proxy.sh
+++ b/scripts/setup_signer_proxy.sh
@@ -23,13 +23,13 @@ function set_up_env() {
 
   if [[ "$(uname)" == 'Linux' ]]; then
      BUILD_SCRIPT="build/scripts/linux_amd64.sh"
-     SIGNER_BINARY="build/bin/linux_amd64/signer"
-     SIGNER_SHARED_LIB="build/bin/linux_amd64/libsigner.so"
+     SIGNER_BINARY="build/bin/linux_amd64/ecp"
+     SIGNER_SHARED_LIB="build/bin/linux_amd64/libecp.so"
      TEST_BINARY_FOLDER="$PWD/tests/testing_utils/signer_binaries/linux64"
   elif [[ "$(uname)" == 'Darwin' ]]; then
      BUILD_SCRIPT="build/scripts/darwin_amd64.sh"
-     SIGNER_BINARY="build/bin/darwin_amd64/signer"
-     SIGNER_SHARED_LIB="build/bin/darwin_amd64/libsigner.dylib"
+     SIGNER_BINARY="build/bin/darwin_amd64/ecp"
+     SIGNER_SHARED_LIB="build/bin/darwin_amd64/libecp.dylib"
      TEST_BINARY_FOLDER="$PWD/tests/testing_utils/signer_binaries/mac64"
   else
     echo "This script only supports Linux and MacOS."
@@ -39,20 +39,20 @@ function set_up_env() {
 
 function install_proxy_binaries() {
   BUILD_DIR=$(mktemp -d proxy_signer_buildXXX)
-  pushd $BUILD_DIR
+  pushd "$BUILD_DIR"
   git clone $ENTERPRISE_CERTIFICATE_PROXY_REPO --depth 1
   pushd enterprise-certificate-proxy
 
-  sh $BUILD_SCRIPT
+  sh "$BUILD_SCRIPT"
 
-  mkdir -p $TEST_BINARY_FOLDER
+  mkdir -p "$TEST_BINARY_FOLDER"
 
-  mv $SIGNER_BINARY $TEST_BINARY_FOLDER
-  mv $SIGNER_SHARED_LIB $TEST_BINARY_FOLDER
+  mv "$SIGNER_BINARY" "$TEST_BINARY_FOLDER"
+  mv "$SIGNER_SHARED_LIB" "$TEST_BINARY_FOLDER"
 
   popd
   popd
-  rm -rf $BUILD_DIR
+  rm -rf "$BUILD_DIR"
 }
 
 check_dependencies

--- a/tests/testing_utils/utils.py
+++ b/tests/testing_utils/utils.py
@@ -17,8 +17,8 @@ def _generate_mac_enterprise_cert_json(issuer):
         issuer = "Google Endpoint Verification"
 
     libs = {
-        "signer_binary": os.path.join(signer_binaries_folder, "mac64", "signer"),
-        "signer_library": os.path.join(signer_binaries_folder, "mac64", "libsigner.dylib"),
+        "signer_binary": os.path.join(signer_binaries_folder, "mac64", "ecp"),
+        "signer_library": os.path.join(signer_binaries_folder, "mac64", "libecp.dylib"),
         "offload_library": os.path.join(build_folder, "libtls_offload.dylib")
     }
 
@@ -38,8 +38,8 @@ def _generate_linux_enterprise_cert_json(issuer):
         issuer = "Google Endpoint Verification"
 
     libs = {
-        "signer_binary": os.path.join(signer_binaries_folder, "linux64", "signer"),
-        "signer_library": os.path.join(signer_binaries_folder, "linux64", "libsigner.so"),
+        "signer_binary": os.path.join(signer_binaries_folder, "linux64", "ecp"),
+        "signer_library": os.path.join(signer_binaries_folder, "linux64", "libecp.so"),
         "offload_library": os.path.join(build_folder, "libtls_offload.so")
     }
 

--- a/tests/testing_utils/utils.py
+++ b/tests/testing_utils/utils.py
@@ -16,16 +16,14 @@ def _generate_mac_enterprise_cert_json(issuer):
     if issuer is None:
         issuer = "Google Endpoint Verification"
 
-    cert_info = { "issuer" : issuer }
-
     libs = {
         "signer_binary": os.path.join(signer_binaries_folder, "mac64", "signer"),
-        "signer_library": os.path.join(signer_binaries_folder, "mac64", "signer.dylib"),
-        "offload_library": os.path.join(build_folder, "libcertificate_offload.dylib")
+        "signer_library": os.path.join(signer_binaries_folder, "mac64", "libsigner.dylib"),
+        "offload_library": os.path.join(build_folder, "libtls_offload.dylib")
     }
 
     enterprise_cert_dict = {
-        "cert_info": cert_info,
+        "cert_configs": {"macos_keychain": {"issuer": issuer}},
         "libs": libs,
         "version": "1"
     }
@@ -39,16 +37,14 @@ def _generate_linux_enterprise_cert_json(issuer):
     if issuer is None:
         issuer = "Google Endpoint Verification"
 
-    cert_info = { "issuer" : issuer }
-
     libs = {
         "signer_binary": os.path.join(signer_binaries_folder, "linux64", "signer"),
-        "signer_library": os.path.join(signer_binaries_folder, "linux64", "signer.so"),
-        "offload_library": os.path.join(build_folder, "libcertificate_offload.so")
+        "signer_library": os.path.join(signer_binaries_folder, "linux64", "libsigner.so"),
+        "offload_library": os.path.join(build_folder, "libtls_offload.so")
     }
 
     enterprise_cert_dict = {
-        "cert_info": cert_info,
+        "cert_configs": {"pkcs11": {"issuer": issuer}},
         "libs": libs,
         "version": "1"
     }
@@ -70,4 +66,4 @@ def generate_enterprise_cert_file(issuer = None):
     else:
         enterprise_cert_json = _generate_linux_enterprise_cert_json(issuer)
     return _write_enterprise_cert_json(enterprise_cert_json)
-    
+


### PR DESCRIPTION
- fix: Go integration server uses a minimum TLS version of 1.3.
- refactor: ECP Config schema update. Googlers see go/enterpise-cert-config
