### PR TITLE
fix: Segfault when OpenSSL queries signature length.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies
-        run: brew update && brew install cmake openssl@3
+        run: brew update && brew install cmake openssl@3.0
       - name: Build Library
-        run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" cmake -S . -B build -DENABLE_UNIT_TESTS=TRUE && cmake --build build
+        run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@3.0)" cmake -S . -B build -DENABLE_UNIT_TESTS=TRUE && cmake --build build
       - name: Set up Signer Proxy Binaries
         run: ./scripts/setup_signer_proxy.sh
       - name: Integration Test

--- a/src/offload.cpp
+++ b/src/offload.cpp
@@ -190,6 +190,10 @@ int CustomDigestSign(EVP_MD_CTX *ctx, unsigned char *sig, size_t *sig_len,
       LogInfo("Unsupported ECDSA hash");
       return 0;
     }
+    if (sig == NULL) {
+      *sig_len = 72;
+      return 1;
+    }
   } else if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA) {
     const EVP_MD *md;
     if (EVP_PKEY_CTX_get_signature_md(pctx, &md) != 1 ||
@@ -213,6 +217,10 @@ int CustomDigestSign(EVP_MD_CTX *ctx, unsigned char *sig, size_t *sig_len,
         (val != EVP_MD_size(md) && val != -1)) {
       LogInfo("Unsupported RSA-PSS salt length");
       return 0;
+    }
+    if (sig == NULL) {
+      *sig_len = 256;
+      return 1;
     }
   } else {
     LogInfo("Unsupported key");


### PR DESCRIPTION
Migrating to OpenSSL 3 caused a regression resulting in a NULL pointer exception. Previously the signature buffer was allocated. 

Now, OpenSSL wants to query for the signature's size _before_ allocating the memory. I am not sure why this code worked before, as the function signature did not change. 

I did not do a thorough investigation, this is based on knowledge I acquired when implementing the ECP provider.