### PR TITLE
chore: replace googleapis-auth with cloud-sdk-auth-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @googleapis/googleapis-auth @andyrzhao @shinfan
+* @googleapis/cloud-sdk-auth-team @andyrzhao @shinfan


### PR DESCRIPTION
This PR replaces the old googleapis-auth team with the new cloud-sdk-auth-team.

b/478003109